### PR TITLE
Modifications

### DIFF
--- a/vue-upload-client/src/graphql/mutations/CreatePost.gql
+++ b/vue-upload-client/src/graphql/mutations/CreatePost.gql
@@ -1,4 +1,4 @@
-mutation($title: String!, $content: String!, $image: Upload!) {
+mutation CreatePost($title: String!, $content: String!, $image: Upload!) {
     createPostWithArgResolver(
         input: { title: $title, content: $content, image: $image }
     ) {

--- a/vue-upload-client/src/graphql/queries/GetPosts.gql
+++ b/vue-upload-client/src/graphql/queries/GetPosts.gql
@@ -1,4 +1,4 @@
-query {
+query GetPosts{
     posts {
         data {
             title

--- a/vue-upload-client/src/views/Home.vue
+++ b/vue-upload-client/src/views/Home.vue
@@ -6,35 +6,37 @@
                 <!-- Some content -->
                 <div v-if="loading">Loading...</div>
                 <div v-else class="row">
-                    <div
-                        v-for="post of data.posts.data"
-                        :key="post.id"
-                        class="col-12 col-md-6 col-lg-4 mt-2"
-                    >
-                        <b-card
-                            border-variant="primary"
-                            header-bg-variant="primary"
-                            header-text-variant="white"
-                            :header="post.title"
-                            style="height:400px;"
+                    <template v-if="data">
+                        <div
+                            v-for="post of data.posts.data"
+                            :key="post.id"
+                            class="col-12 col-md-6 col-lg-4 mt-2"
                         >
-                            <b-card-text>
-                                <img
-                                    :src="
-                                        `http://localhost:8000/storage/${post.image}`
-                                    "
-                                    alt="cover image"
-                                    style="max-width:200px; max-height:300px;"
-                                    class="rounded"
-                                />
-                                <div>{{ post.content }}</div>
-                            </b-card-text>
-
-                            <b-button href="#" variant="primary"
-                                >Go somewhere</b-button
+                            <b-card
+                                border-variant="primary"
+                                header-bg-variant="primary"
+                                header-text-variant="white"
+                                :header="post.title"
+                                style="height:400px;"
                             >
-                        </b-card>
-                    </div>
+                                <b-card-text>
+                                    <img
+                                        :src="
+                                            `http://localhost:8000/storage/${post.image}`
+                                        "
+                                        alt="cover image"
+                                        style="max-width:200px; max-height:300px;"
+                                        class="rounded"
+                                    />
+                                    <div>{{ post.content }}</div>
+                                </b-card-text>
+
+                                <b-button href="#" variant="primary"
+                                    >Go somewhere</b-button
+                                >
+                            </b-card>
+                        </div>
+                    </template>
                 </div>
             </template>
         </ApolloQuery>


### PR DESCRIPTION
Hi @wolfiton

So please read commit messages.
For your problem with `posts on null` - I never was using `<ApolloQuery>` component, I call `$apollo.query()` in the JS block instead, so I don't know why, but somehow `<ApolloQuery>` changes `loading` to true, but `data` is still not updated. So it comes to the situation, that vue rerenders the condition and jumps into second block, because `loading` became false, but data is still not accessable. So you need to add one more `v-if` to ensure that data is not null.

Generally with this behaviour you are able to separate what user is seeing when query is loading, when query is loaded and `data` is filled with response, and when query is loaded, but `data` is `null`. Typically `data` is null, if server responses an error. In this situation `data` is always `null` and there is `error` property, where error details are stored. I just took a look - there is `result.error` in slot-scope within `<ApolloQuery>`, so you have ability to show it to user.
In my project while using queries in JS block I catch this case with `.catch()`